### PR TITLE
Tofn compatibility fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ default = ["openssl"]
 gmp = ["unknown_order/gmp"]
 openssl = ["unknown_order/openssl"]
 rust = ["unknown_order/rust"]
-wasm = ["getrandom", "rand", "wasm-bindgen", "serde-wasm-bindgen"]
+wasm = ["getrandom", "wasm-bindgen", "serde-wasm-bindgen"]
 
 [dependencies]
 digest = "0.9"
 getrandom = { version = "0.2", features = ["js"], optional = true }
-rand = { version = "0.8", optional = true }
+rand_core = { version = "0.6", default_features = false }
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_bare = "0.5"
 unknown_order = { version = "0.5.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ default = ["openssl"]
 gmp = ["unknown_order/gmp"]
 openssl = ["unknown_order/openssl"]
 rust = ["unknown_order/rust"]
-wasm = ["getrandom", "rand", "wasm-bindgen"]
+wasm = ["getrandom", "rand", "wasm-bindgen", "serde-wasm-bindgen"]
 
 [dependencies]
 digest = "0.9"
@@ -28,6 +28,7 @@ serde_bare = "0.5"
 unknown_order = { version = "0.5.0", default-features = false }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"], optional = true }
 zeroize = { version = "1.4", features = ["zeroize_derive"] }
+serde-wasm-bindgen = { version = "0.4", optional = true }
 
 [dev-dependencies]
 elliptic-curve = "0.9"

--- a/src/decryptionkey.rs
+++ b/src/decryptionkey.rs
@@ -1,4 +1,5 @@
 use crate::{mod_in, Ciphertext, EncryptionKey};
+use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use unknown_order::BigNumber;
 use zeroize::Zeroize;
@@ -31,6 +32,18 @@ impl DecryptionKey {
     pub fn random() -> Option<Self> {
         let mut p = BigNumber::prime(1024);
         let mut q = BigNumber::prime(1024);
+        let res = Self::with_primes_unchecked(&p, &q);
+        // Make sure the primes are zero'd
+        p.zeroize();
+        q.zeroize();
+        res
+    }
+
+    #[cfg(any(feature = "gmp", feature = "rust"))]
+    /// Create a new decryption key using the provided `rng`
+    pub fn from_rng_with_safe_primes(rng: &mut (impl CryptoRng + RngCore)) -> Option<Self> {
+        let mut p = BigNumber::safe_prime_from_rng(1024, rng);
+        let mut q = BigNumber::safe_prime_from_rng(1024, rng);
         let res = Self::with_primes_unchecked(&p, &q);
         // Make sure the primes are zero'd
         p.zeroize();

--- a/src/decryptionkey.rs
+++ b/src/decryptionkey.rs
@@ -1,4 +1,6 @@
 use crate::{mod_in, Ciphertext, EncryptionKey};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use unknown_order::BigNumber;

--- a/src/decryptionkey.rs
+++ b/src/decryptionkey.rs
@@ -4,7 +4,7 @@ use unknown_order::BigNumber;
 use zeroize::Zeroize;
 
 /// A Paillier decryption key
-#[derive(Clone, Debug, Deserialize, Serialize, Zeroize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize, Zeroize)]
 #[zeroize(drop)]
 pub struct DecryptionKey {
     pub(crate) pk: EncryptionKey,

--- a/src/encryptionkey.rs
+++ b/src/encryptionkey.rs
@@ -1,4 +1,6 @@
 use crate::{mod_in, Ciphertext, DecryptionKey, Nonce};
+use alloc::string::String;
+use alloc::vec::Vec;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use unknown_order::BigNumber;
 use zeroize::Zeroize;

--- a/src/encryptionkey.rs
+++ b/src/encryptionkey.rs
@@ -4,7 +4,7 @@ use unknown_order::BigNumber;
 use zeroize::Zeroize;
 
 /// A Paillier encryption key
-#[derive(Clone, Debug, Zeroize)]
+#[derive(Clone, Debug, PartialEq, Zeroize)]
 pub struct EncryptionKey {
     pub(crate) n: BigNumber,  // N = p * q, where p,q are primes
     pub(crate) nn: BigNumber, // N^2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! Paillier-rs contains Paillier's cryptosystem (1999)
 //! Public-Key Cryptosystems based on composite degree residuosity class.
 //! See <http://citeseerx.ist.psu.edu/download?doi=10.1.1.4035&rep=rep1&type=pdf>
+#![no_std]
 #![deny(
     warnings,
     missing_docs,
@@ -14,6 +15,8 @@
     trivial_numeric_casts
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
 
 #[cfg(feature = "wasm")]
 #[macro_use]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -46,9 +46,7 @@ macro_rules! wasm_slice_impl {
             type Error = &'static str;
 
             fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
-                value
-                    .into_serde::<$name>()
-                    .map_err(|_| "unable to deserialize value")
+                serde_wasm_bindgen::from_value(value).map_err(|_| "unable to deserialize value")
             }
         }
     };

--- a/src/proof_psf.rs
+++ b/src/proof_psf.rs
@@ -1,4 +1,6 @@
 use crate::{mod_in, DecryptionKey, EncryptionKey};
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use digest::{
     generic_array::{typenum::Unsigned, GenericArray},
     Digest,

--- a/tests/paillier.rs
+++ b/tests/paillier.rs
@@ -144,7 +144,7 @@ fn bytes() {
     assert_eq!(pk1.n(), pk.n());
 
     let bytes = sk.to_bytes();
-    assert_eq!(bytes.len(), 1032);
+    assert_eq!(bytes.len(), 1550);
     let res = DecryptionKey::from_bytes(bytes.as_slice());
     assert!(res.is_ok());
     let sk1 = res.unwrap();


### PR DESCRIPTION
This is a continuation of https://github.com/mikelodder7/unknown_order/pull/7 . This PR exposes some internals that are required by the GG20 implementation https://github.com/entropyxyz/tofn (namely, https://github.com/entropyxyz/tofn/pull/27). Please feel free to propose a different API, I understand that you may have a different view on how these things can be exposed in a safe manner.

- Fix the compilation with `wasm` feature enabled (using `serde_wasm_bindgen`)
- Derive `PartialEq` for `EncryptionKey` and `DecryptionKey`
- Store `n`, `p`, and `q` in `DecryptionKey` to assist with ZKP creation
- Add `DecryptionKey::from_rng_with_safe_primes()`
- Add `DecryptionKey::decrypt_unchecked()`, `DecryptionKey::decrypt_with_randomness()`, `EncryptionKey::encrypt_unchecked()`, `EncryptionKey::add_unchecked()` and `EncryptionKey::mul_unchecked()`
- Make the crate `no_std`.