### PR TITLE
Add `EncryptionKey::from_n` constructor

### DIFF
--- a/src/decryptionkey.rs
+++ b/src/decryptionkey.rs
@@ -50,12 +50,7 @@ impl DecryptionKey {
         }
         let pm1: BigNumber = p - 1;
         let qm1: BigNumber = q - 1;
-        let n = p * q;
-        let nn = &n * &n;
-        let pk = EncryptionKey {
-            n: n.clone(),
-            nn: nn.clone(),
-        };
+        let pk = EncryptionKey::from_n(p * q);
         let lambda = pm1.lcm(&qm1);
         if lambda.is_zero() {
             return None;
@@ -63,11 +58,11 @@ impl DecryptionKey {
         let totient = &pm1 * &qm1;
 
         // (N+1)^lambda mod N^2
-        let t: BigNumber = &n + 1;
-        let tt = t.modpow(&lambda, &nn);
+        let t: BigNumber = pk.n() + 1;
+        let tt = t.modpow(&lambda, pk.nn());
 
         // L((N+1)^lambda mod N^2)^-1 mod N
-        let uu = pk.l(&tt).map(|uu| uu.invert(&n));
+        let uu = pk.l(&tt).map(|uu| uu.invert(pk.n()));
         match uu {
             None => None,
             Some(u_inv) => u_inv.map(|u| DecryptionKey {

--- a/src/encryptionkey.rs
+++ b/src/encryptionkey.rs
@@ -28,10 +28,7 @@ impl<'de> Deserialize<'de> for EncryptionKey {
         D: Deserializer<'de>,
     {
         let n = BigNumber::deserialize(deserializer)?;
-        Ok(Self {
-            n: n.clone(),
-            nn: &n * &n,
-        })
+        Ok(Self::from_n(n))
     }
 }
 
@@ -122,10 +119,12 @@ impl EncryptionKey {
     pub fn from_bytes<B: AsRef<[u8]>>(data: B) -> Result<Self, String> {
         let data = data.as_ref();
         let n = BigNumber::from_slice(data);
-        Ok(Self {
-            n: n.clone(),
-            nn: &n * &n,
-        })
+        Ok(Self::from_n(n))
+    }
+
+    /// Constructs encryption key from the Paillier modulus
+    pub fn from_n(n: BigNumber) -> Self {
+        Self { nn: &n * &n, n }
     }
 
     /// The Paillier modulus


### PR DESCRIPTION
Currently, there is no way to construct `EncryptionKey` from paillier modulus `N` as `BigNumber`. Note that crate allows constructing `DecryptionKey` from primes `p` and `q`, which is similar functionality. PR adds missing constructor.