### PR TITLE
Add the ability to test wasm and fixes a few linter errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ crypto = ["unknown_order/crypto"]
 gmp = ["unknown_order/gmp"]
 openssl = ["unknown_order/openssl"]
 rust = ["unknown_order/rust"]
-wasm = ["getrandom", "rand", "wasm-bindgen"]
+wasm = ["getrandom", "rand", "wasm-bindgen", "serde-wasm-bindgen"]
 
 [dependencies]
 digest = "0.10"
@@ -26,6 +26,7 @@ getrandom = { version = "0.2", features = ["js"], optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["serde_derive"] }
 serde_bare = "0.5"
+serde-wasm-bindgen = { version = "0.6", optional = true }
 unknown_order = { version = "0.8", default-features = false  }
 wasm-bindgen = { version = "0.2", default-features = false, features = ["serde-serialize"], optional = true }
 zeroize = { version = "1.5", features = ["zeroize_derive"] }
@@ -34,6 +35,7 @@ zeroize = { version = "1.5", features = ["zeroize_derive"] }
 elliptic-curve = "0.13"
 hex = "0.4"
 k256 = { version = "0.13", features = ["arithmetic"] }
+wasm-bindgen-test = "0.3"
 rand = "0.8"
 multibase = "0.9"
 sha2 = "0.10"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,13 +42,11 @@ macro_rules! wasm_slice_impl {
             }
         }
 
-        impl std::convert::TryFrom<wasm_bindgen::JsValue> for $name {
+        impl TryFrom<wasm_bindgen::JsValue> for $name {
             type Error = &'static str;
 
             fn try_from(value: wasm_bindgen::JsValue) -> Result<Self, Self::Error> {
-                value
-                    .into_serde::<$name>()
-                    .map_err(|_| "unable to deserialize value")
+                serde_wasm_bindgen::from_value(value).map_err(|_| "unable to deserialize value")
             }
         }
     };

--- a/tests/paillier.rs
+++ b/tests/paillier.rs
@@ -17,7 +17,6 @@ fn b10(s: &str) -> BigNumber {
     BigNumber::from_slice(bytes.as_slice())
 }
 
-#[test]
 fn encrypt() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -46,7 +45,6 @@ fn encrypt() {
     }
 }
 
-#[test]
 fn add() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -73,7 +71,6 @@ fn add() {
     assert_eq!(m3, BigNumber::from(13));
 }
 
-#[test]
 fn mul() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -97,7 +94,6 @@ fn mul() {
     assert_eq!(m3, BigNumber::from(42));
 }
 
-#[test]
 fn serialization() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[2]), &b10(TEST_PRIMES[3]));
     assert!(res.is_some());
@@ -131,7 +127,6 @@ fn serialization() {
     assert_eq!(sk.n(), sk1.n());
 }
 
-#[test]
 fn bytes() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[2]), &b10(TEST_PRIMES[3]));
     assert!(res.is_some());
@@ -154,7 +149,6 @@ fn bytes() {
     assert_eq!(sk.n(), sk1.n());
 }
 
-#[test]
 fn proof() {
     use k256::elliptic_curve::group::prime::PrimeCurveAffine;
 
@@ -194,7 +188,6 @@ fn proof() {
     assert!(res.is_err());
 }
 
-#[test]
 fn all() {
     let res = DecryptionKey::random();
     assert!(res.is_some());
@@ -221,4 +214,46 @@ fn all() {
         let res = pk.encrypt(&b, None);
         assert!(res.is_none());
     }
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_encrypt() {
+    encrypt()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_add() {
+    add()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_mul() {
+    mul()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_serialization() {
+    serialization()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_bytes() {
+    bytes()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_proof() {
+    proof()
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
+fn test_all() {
+    all()
 }

--- a/tests/paillier.rs
+++ b/tests/paillier.rs
@@ -17,6 +17,8 @@ fn b10(s: &str) -> BigNumber {
     BigNumber::from_slice(bytes.as_slice())
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn encrypt() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -45,6 +47,8 @@ fn encrypt() {
     }
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn add() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -71,6 +75,8 @@ fn add() {
     assert_eq!(m3, BigNumber::from(13));
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn mul() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[0]), &b10(TEST_PRIMES[1]));
     assert!(res.is_some());
@@ -94,6 +100,8 @@ fn mul() {
     assert_eq!(m3, BigNumber::from(42));
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn serialization() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[2]), &b10(TEST_PRIMES[3]));
     assert!(res.is_some());
@@ -127,6 +135,8 @@ fn serialization() {
     assert_eq!(sk.n(), sk1.n());
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn bytes() {
     let res = DecryptionKey::with_primes_unchecked(&b10(TEST_PRIMES[2]), &b10(TEST_PRIMES[3]));
     assert!(res.is_some());
@@ -149,6 +159,8 @@ fn bytes() {
     assert_eq!(sk.n(), sk1.n());
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn proof() {
     use k256::elliptic_curve::group::prime::PrimeCurveAffine;
 
@@ -188,6 +200,8 @@ fn proof() {
     assert!(res.is_err());
 }
 
+#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
+#[test]
 fn all() {
     let res = DecryptionKey::random();
     assert!(res.is_some());
@@ -214,46 +228,4 @@ fn all() {
         let res = pk.encrypt(&b, None);
         assert!(res.is_none());
     }
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_encrypt() {
-    encrypt()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_add() {
-    add()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_mul() {
-    mul()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_serialization() {
-    serialization()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_bytes() {
-    bytes()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_proof() {
-    proof()
-}
-
-#[cfg_attr(feature = "wasm", wasm_bindgen_test::wasm_bindgen_test)]
-#[test]
-fn test_all() {
-    all()
 }


### PR DESCRIPTION
This library can be compiled to WASM, but supporting testing for that target doesn't work out of the box. This PR addresses that. 

While testing wasm, the compiler reported a few linter errors and would fail to compile (due to the project config). I've fixed them:
- Unnecessary qualified `TryFrom`
- Recommended to use `serde-wasm-bindgen`

## How to test WASM

[Install wasm-pack](https://rustwasm.github.io/wasm-pack/installer)

Run the test command. I'm using the `--release` flag for speed and opting to use node (which expects a node to be in the environment). Running in the browser can be configured with more code changes, but using node should be sufficient for local testing. Unfortunately, the wasm target only works with the `rust` or `crypto` feature as `gmp` or `openssl` do not support wasm targets:

- `wasm-pack test --node --release --no-default-features --features wasm,rust`
- `wasm-pack test --node --release --no-default-features --features wasm,crypto` or the shorter command `wasm-pack test --node --release --features wasm`

Results:
```    Finished release [optimized] target(s) in 3.61s
[INFO]: ⬇️  Installing wasm-bindgen...
    Finished release [optimized] target(s) in 0.04s
     Running unittests src/lib.rs (target/wasm32-unknown-unknown/release/deps/libpaillier-db39394c44027fb1.wasm)
no tests to run!
     Running tests/paillier.rs (target/wasm32-unknown-unknown/release/deps/paillier-965e043a1c0af98c.wasm)
Set timeout to 20 seconds...
running 7 tests                                   

test paillier::test_all ... ok
test paillier::test_proof ... ok
test paillier::test_bytes ... ok
test paillier::test_serialization ... ok
test paillier::test_mul ... ok
test paillier::test_add ... ok
test paillier::test_encrypt ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 filtered out
```